### PR TITLE
fix: enable sidebar navigation between dashboard tasks projects and r…

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,15 +14,15 @@
       </div>
 
       <nav class="nav-menu">
-        <a href="javascript:void(0)" class="nav-item active">Dashboard</a>
-        <a href="javascript:void(0)" class="nav-item">Tasks</a>
-        <a href="javascript:void(0)" class="nav-item">Projects</a>
-        <a href="javascript:void(0)" class="nav-item">Reminders</a>
+        <a href="#dashboard" class="nav-item active">Dashboard</a>
+        <a href="#tasks" class="nav-item">Tasks</a>
+        <a href="#projects" class="nav-item">Projects</a>
+        <a href="#reminders" class="nav-item">Reminders</a>
       </nav>
     </aside>
 
     <main class="main-content">
-      <header class="topbar">
+      <header class="topbar" id="dashboard">
         <div>
           <h1>Dashboard Overview</h1>
           <p>Track your tasks and progress in one place.</p>
@@ -111,7 +111,7 @@
         </div>
       </section>
 
-      <section class="task-list-section">
+      <section class="task-list-section" id="tasks">
         <div class="section-header">
           <h2>Task List</h2>
           <button id="refreshBtn" class="refresh-btn">Refresh</button>
@@ -121,7 +121,7 @@
         <div id="taskList" class="task-list"></div>
       </section>
 
-      <section class="projects-section">
+      <section class="projects-section" id="projects">
         <div class="section-header">
           <h2>Projects</h2>
         </div>
@@ -130,7 +130,7 @@
         <div id="projectList" class="project-list"></div>
       </section>
 
-      <section class="reminders-section">
+      <section class="reminders-section" id="reminders">
         <div class="section-header">
           <h2>Reminders & Overdue Tasks</h2>
         </div>

--- a/script.js
+++ b/script.js
@@ -452,6 +452,17 @@ async function handleTaskSubmit(event) {
   }
 }
 
+function setupSidebarNavigation() {
+  const navItems = document.querySelectorAll(".nav-item");
+
+  navItems.forEach((item) => {
+    item.addEventListener("click", () => {
+      navItems.forEach((nav) => nav.classList.remove("active"));
+      item.classList.add("active");
+    });
+  });
+}
+
 if (refreshBtn) refreshBtn.addEventListener("click", loadTasks);
 if (taskForm) taskForm.addEventListener("submit", handleTaskSubmit);
 if (generateBtn) generateBtn.addEventListener("click", handleGenerateSubtasks);
@@ -460,4 +471,5 @@ if (clearSubtasksBtn) clearSubtasksBtn.addEventListener("click", clearGeneratedS
 document.addEventListener("DOMContentLoaded", () => {
   renderGeneratedSubtasks();
   loadTasks();
+  setupSidebarNavigation();
 });

--- a/style.css
+++ b/style.css
@@ -4,6 +4,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: Arial, sans-serif;
   background-color: #f5f7fb;
@@ -53,6 +57,13 @@ body {
 .main-content {
   flex: 1;
   padding: 30px;
+}
+
+.topbar,
+.task-list-section,
+.projects-section,
+.reminders-section {
+  scroll-margin-top: 20px;
 }
 
 .topbar {


### PR DESCRIPTION
This PR fixes the sidebar navigation links in the Smart Task Manager frontend.

Changes made:
- Updated sidebar links to navigate to page sections
- Added IDs for dashboard, tasks, projects, and reminders sections
- Added smooth scrolling in CSS
- Added active state handling for sidebar links in JavaScript

How to test:
1. Open the app
2. Click Dashboard, Tasks, Projects, and Reminders in the sidebar
3. Confirm each link scrolls to the correct section