### PR TITLE
Fix/cicd secret names

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,9 +27,9 @@ jobs:
     
     - name: Run tests
       env:
-        MONGO_URI: ${{ secrets.MongoDB_URI }}
-        MONGO_DB_NAME: System_Deployment
-        GEMINI_API_KEY: ${{ secrets.Gemini_API_KEY }}
+        MONGO_URI: ${{ secrets.MONGOURI }}
+        MONGO_DB_NAME: ${{ secrets.MONGODB_NAME }}
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: |
         cd backend
         pytest tests/ -v --cov=. --cov-report=term-missing
@@ -37,8 +37,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DockerHub_USERNAME }}
-        password: ${{ secrets.DockerHub_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     
     - name: Build and test Docker image
       uses: docker/build-push-action@v5
@@ -46,20 +46,19 @@ jobs:
         context: .
         push: false
         tags: |
-          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:latest
-          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
+          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:latest
+          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:${{ github.sha }}
     
     - name: Smoke test container
       run: |
-        docker run -d -p 10000:10000 \
-          -e PORT=10000 \
-          -e MONGO_URI="${{ secrets.MongoDB_URI }}" \
-          -e MONGO_DB_NAME="System_Deployment" \
-          -e GEMINI_API_KEY="${{ secrets.Gemini_API_KEY }}" \
+        docker run -d -p 5000:5000 \
+          -e MONGO_URI="${{ secrets.MONGOURI }}" \
+          -e MONGO_DB_NAME="${{ secrets.MONGODB_NAME }}" \
+          -e GEMINI_API_KEY="${{ secrets.GEMINI_API_KEY }}" \
           --name test-container \
-          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
-        sleep 8
-        curl --fail http://localhost:10000/health || exit 1
+          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:${{ github.sha }}
+        sleep 5
+        curl --fail http://localhost:5000/health || exit 1
         docker stop test-container
         docker rm test-container
     
@@ -70,9 +69,9 @@ jobs:
         context: .
         push: true
         tags: |
-          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:latest
-          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
+          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:latest
+          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:${{ github.sha }}
 
     - name: Trigger Render deploy
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: curl -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"
+      run: curl -X POST "${{ secrets.RENDER_DEPLOY_URL }}"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,9 +27,9 @@ jobs:
     
     - name: Run tests
       env:
-        MONGO_URI: ${{ secrets.MONGO_URI }}
-        MONGO_DB_NAME: test_db
-        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        MONGO_URI: ${{ secrets.MongoDB_URI }}
+        MONGO_DB_NAME: System_Deployment
+        GEMINI_API_KEY: ${{ secrets.Gemini_API_KEY }}
       run: |
         cd backend
         pytest tests/ -v --cov=. --cov-report=term-missing
@@ -37,8 +37,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DockerHub_USERNAME }}
+        password: ${{ secrets.DockerHub_TOKEN }}
     
     - name: Build and test Docker image
       uses: docker/build-push-action@v5
@@ -46,18 +46,17 @@ jobs:
         context: .
         push: false
         tags: |
-          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:latest
-          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:${{ github.sha }}
+          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:latest
+          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
     
     - name: Smoke test container
       run: |
         docker run -d -p 5000:5000 \
-          -e MONGO_URI="${{ secrets.MONGO_URI }}" \
-          -e MONGO_DB_NAME="smart_task_manager" \
-          -e GEMINI_API_KEY="${{ secrets.GEMINI_API_KEY }}" \
-          -e STUDENT_ID="${{ secrets.STUDENT_ID }}" \
+          -e MONGO_URI="${{ secrets.MongoDB_URI }}" \
+          -e MONGO_DB_NAME="System_Deployment" \
+          -e GEMINI_API_KEY="${{ secrets.Gemini_API_KEY }}" \
           --name test-container \
-          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:${{ github.sha }}
+          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
         sleep 5
         curl --fail http://localhost:5000/health || exit 1
         docker stop test-container
@@ -70,15 +69,7 @@ jobs:
         context: .
         push: true
         tags: |
-          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:latest
-          ${{ secrets.DOCKERHUB_USERNAME }}/smart-task-manager:${{ github.sha }}
+          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:latest
+          ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
 
-  deploy:
-    needs: test-and-build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Trigger Render Deploy
-      run: |
-        curl -X POST "${{ secrets.RENDER_DEPLOY_URL }}"
+ 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,14 +51,15 @@ jobs:
     
     - name: Smoke test container
       run: |
-        docker run -d -p 5000:5000 \
+        docker run -d -p 10000:10000 \
+          -e PORT=10000 \
           -e MONGO_URI="${{ secrets.MongoDB_URI }}" \
           -e MONGO_DB_NAME="System_Deployment" \
           -e GEMINI_API_KEY="${{ secrets.Gemini_API_KEY }}" \
           --name test-container \
           ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
-        sleep 5
-        curl --fail http://localhost:5000/health || exit 1
+        sleep 8
+        curl --fail http://localhost:10000/health || exit 1
         docker stop test-container
         docker rm test-container
     
@@ -72,4 +73,6 @@ jobs:
           ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:latest
           ${{ secrets.DockerHub_USERNAME }}/smart-task-manager:${{ github.sha }}
 
- 
+    - name: Trigger Render deploy
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: curl -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -75,3 +75,5 @@ jobs:
     - name: Trigger Render deploy
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: curl -X POST "${{ secrets.RENDER_DEPLOY_URL }}"
+
+      

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,7 @@
 Flask==3.0.3
+flask-cors==4.0.0
 google-generativeai==0.8.3
 gunicorn==23.0.0
 pymongo==4.16.0
 python-dotenv==1.0.1
+requests==2.32.3


### PR DESCRIPTION
## Summary
Fixes the CI/CD pipeline by correcting secret names to match GitHub repository secrets.

## Changes Made
- Changed `MongoDB_URI` → `MONGOURI`
- Changed `MONGO_DB_NAME` → `MONGODB_NAME`
- Changed `RENDER_DEPLOY_HOOK` → `RENDER_DEPLOY_URL`
- Fixed case sensitivity for `GEMINI_API_KEY`

## Testing
- [ ] CI pipeline passes
- [ ] Secrets are found correctly
- [ ] Docker image pushes successfully